### PR TITLE
PL-4952 Hide PID/fodselsnummer in nginx log

### DIFF
--- a/Dockerfile-fss
+++ b/Dockerfile-fss
@@ -3,5 +3,4 @@ FROM nginxinc/nginx-unprivileged
 COPY /build /usr/share/nginx/html
 
 # Will extract environment variables before nginx starts (ref. https://hub.docker.com/_/nginx):
-COPY nginx/fss.conf /etc/nginx/templates/app.conf.template
-
+COPY nginx/fss.conf /etc/nginx/templates/default.conf.template

--- a/Dockerfile-gcp
+++ b/Dockerfile-gcp
@@ -3,5 +3,4 @@ FROM nginxinc/nginx-unprivileged
 COPY /build /usr/share/nginx/html
 
 # Will extract environment variables before nginx starts (ref. https://hub.docker.com/_/nginx):
-COPY nginx/gcp.conf /etc/nginx/templates/app.conf.template
-
+COPY nginx/gcp.conf /etc/nginx/templates/default.conf.template

--- a/nginx/fss.conf
+++ b/nginx/fss.conf
@@ -1,3 +1,7 @@
+log_format no_pid '$remote_addr - $remote_user [$time_local] '
+                  '"$no_pid_request" $status $body_bytes_sent '
+                  '"$http_user_agent" "$http_x_forwarded_for"';
+
 server {
     listen 8080;
     server_tokens off;
@@ -8,9 +12,16 @@ server {
     gzip_comp_level 9;
     etag on;
     large_client_header_buffers 4 32k;
-
     index index.html index.htm;
+
     location / {
+        set $no_pid_request $request;
+
+        if ($no_pid_request ~ (.*)(fnr|pid)=[^&]*(.*)) {
+            set $no_pid_request $1$2=***********$3;
+        }
+
+        access_log /var/log/nginx/access.log no_pid;
     }
 
     location /pensjon/opptjening/ {
@@ -19,11 +30,13 @@ server {
     }
 
     location = /api/internal/isAlive {
+        access_log off;
         add_header Content-Type text/plain;
         return 200;
     }
 
     location = /api/internal/isReady {
+        access_log off;
         add_header Content-Type text/plain;
         return 200;
     }

--- a/nginx/gcp.conf
+++ b/nginx/gcp.conf
@@ -1,3 +1,7 @@
+log_format no_pid '$remote_addr - $remote_user [$time_local] '
+                  '"$no_pid_request" $status $body_bytes_sent '
+                  '"$http_user_agent" "$http_x_forwarded_for"';
+
 server {
     listen 8080;
     server_tokens off;
@@ -8,9 +12,16 @@ server {
     gzip_comp_level 9;
     etag on;
     large_client_header_buffers 4 32k;
-
     index index.html index.htm;
+
     location / {
+        set $no_pid_request $request;
+
+        if ($no_pid_request ~ (.*)(fnr|pid)=[^&]*(.*)) {
+            set $no_pid_request $1$2=***********$3;
+        }
+
+        access_log /var/log/nginx/access.log no_pid;
     }
 
     location /pensjon/opptjening/ {
@@ -19,11 +30,13 @@ server {
     }
 
     location = /api/internal/isAlive {
+        access_log off;
         add_header Content-Type text/plain;
         return 200;
     }
 
     location = /api/internal/isReady {
+        access_log off;
         add_header Content-Type text/plain;
         return 200;
     }


### PR DESCRIPTION
Erstatter fødselsnummer i URL med `***********` (URLer som har `fnr` eller `pid` som queryparam).

Logger ikke lenger liveness-kall (`/api/internal/isAlive` og `/api/internal/isReady`), da disse både er frekvente og uinteressante.

Bruker `default.conf.template` istedenfor `app.conf.template`, for å unngå at settinger i `default.conf.template` (som ligger i nginx-imaget i utgangspunktet) overstyrer settinger i `app.conf.template`.