### PR TITLE
Test error boundary

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -120,5 +120,7 @@
     "error-status-403": "You do not have access to see this person's pension earnings.",
     "error-status-404": "We are not able to find the page or service you are looking for.",
     "error-status-common": "A technical problem occurred. Please try to log in again later. We are sorry for the inconvenience.",
-    "error-status-nodata": "We can not find any data for you."
+    "error-status-nodata": "We can not find any data for you.",
+    "error-proev-igjen": "Try again"
+
 }

--- a/public/locales/nb/translation.json
+++ b/public/locales/nb/translation.json
@@ -120,5 +120,6 @@
     "error-status-403": "Du har ikke tilgang til å se informasjon om denne personens pensjonsopptjening.",
     "error-status-404": "Vi kan ikke finne siden eller tjenesten du etterspør.",
     "error-status-common": "Det oppstod et teknisk problem. Du kan prøve å logge inn senere. Vi beklager feilen.",
-    "error-status-nodata": "Vi kan ikke finne noe opptjeningsdata for deg."
+    "error-status-nodata": "Vi kan ikke finne noe opptjeningsdata for deg.",
+    "error-proev-igjen": "Prøv igjen"
 }

--- a/public/locales/nn/translation.json
+++ b/public/locales/nn/translation.json
@@ -120,5 +120,6 @@
     "error-status-403": "Du har ikkje tilgang til å sjå informasjon om pensjonsoppteninga til denne personen.",
     "error-status-404": "Vi kan ikkje finne sida eller tenesta du spør etter.",
     "error-status-common": "Det oppstod eit teknisk problem. Du kan prøve å logge inn seinare. Vi beklagar feilen.",
-    "error-status-nodata": "Vi kan ikkje finne oppteningsdata for deg."
+    "error-status-nodata": "Vi kan ikkje finne oppteningsdata for deg.",
+    "error-proev-igjen": "Prøv igjen"
 }

--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -1,17 +1,35 @@
 import React from 'react';
 import {logger} from "./common/logging";
+import Alertstripe from "nav-frontend-alertstriper";
+import { withTranslation } from 'react-i18next';
+import {Knapp} from "nav-frontend-knapper";
 
 class ErrorBoundary extends React.Component {
-  static getDerivedStateFromError() {}
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, count: 0 };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
 
   componentDidCatch(error, errorInfo) {
     console.error(`Uventet feil fra appen under render: ${error}`, errorInfo);
     logger.error(`Uventet feil fra appen under render: ${error} ${errorInfo}`);
+    this.setState({ count: this.state.count + 1})
   }
 
   render() {
+    const { t } = this.props;
+    if(this.state.hasError && this.state.count === 3) {
+      return <div className="mainBody" id="maincontent" tabIndex="-1">
+        <Alertstripe type="feil">{t("error-status-common")}</Alertstripe>
+        <Knapp onClick={() => window.location.reload()}>{t("error-proev-igjen")}</Knapp>
+      </div>
+    }
     return this.props.children;
   }
 }
 
-export default ErrorBoundary;
+export default withTranslation(ErrorBoundary);

--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import {logger} from "./common/logging";
+
+class ErrorBoundary extends React.Component {
+  static getDerivedStateFromError() {}
+
+  componentDidCatch(error, errorInfo) {
+    console.error(`Uventet feil fra appen under render: ${error}`, errorInfo);
+    logger.error(`Uventet feil fra appen under render: ${error} ${errorInfo}`);
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import {logger} from "./common/logging";
-import Alertstripe from "nav-frontend-alertstriper";
-import { withTranslation } from 'react-i18next';
-import {Knapp} from "nav-frontend-knapper";
+import ErrorView from "./ErrorView";
+
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -21,15 +20,11 @@ class ErrorBoundary extends React.Component {
   }
 
   render() {
-    const { t } = this.props;
     if(this.state.hasError && this.state.count === 3) {
-      return <div className="mainBody" id="maincontent" tabIndex="-1">
-        <Alertstripe type="feil">{t("error-status-common")}</Alertstripe>
-        <Knapp onClick={() => window.location.reload()}>{t("error-proev-igjen")}</Knapp>
-      </div>
+      return <ErrorView/>;
     }
     return this.props.children;
   }
 }
 
-export default withTranslation(ErrorBoundary);
+export default ErrorBoundary;

--- a/src/ErrorView.js
+++ b/src/ErrorView.js
@@ -1,11 +1,13 @@
 import React from 'react';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import Alertstripe from "nav-frontend-alertstriper";
 import {Knapp} from "nav-frontend-knapper";
+import './containers/App/App.less';
 
 
-const ErrorView = (props) => {
-    const {t} = props;
+const ErrorView = () => {
+    const { t } = useTranslation();
+
 
     return <div className="mainBody" id="maincontent" tabIndex="-1">
         <Alertstripe type="feil">{t("error-status-common")}</Alertstripe>
@@ -13,4 +15,4 @@ const ErrorView = (props) => {
     </div>
 }
 
-export default withTranslation()(ErrorView);
+export default ErrorView;

--- a/src/ErrorView.js
+++ b/src/ErrorView.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { withTranslation } from 'react-i18next';
+import Alertstripe from "nav-frontend-alertstriper";
+import {Knapp} from "nav-frontend-knapper";
+
+
+const ErrorView = (props) => {
+    const {t} = props;
+
+    return <div className="mainBody" id="maincontent" tabIndex="-1">
+        <Alertstripe type="feil">{t("error-status-common")}</Alertstripe>
+        <Knapp onClick={() => window.location.reload()}>{t("error-proev-igjen")}</Knapp>
+    </div>
+}
+
+export default withTranslation()(ErrorView);

--- a/src/index.js
+++ b/src/index.js
@@ -12,20 +12,23 @@ import './i18n';
 import './index.less';
 import {UnleashContainer} from "./containers/UnleashContainer/UnleashContainer";
 import {initAmplitude} from "./common/amplitude";
+import ErrorBoundary from "./ErrorBoundary";
 
 initAmplitude();
 ReactDOM.render(
-    <Provider store={store}>
-        <Suspense fallback={<NavFrontendSpinner/>}>
-            <UnleashContainer>
-                <Router basename={process.env.PUBLIC_URL}>
-                    <Normaltekst tag="div">
-                        <App />
-                    </Normaltekst>
-                </Router>
-            </UnleashContainer>
-        </Suspense>
-    </Provider>,
+    <ErrorBoundary>
+        <Provider store={store}>
+            <Suspense fallback={<NavFrontendSpinner/>}>
+                <UnleashContainer>
+                    <Router basename={process.env.PUBLIC_URL}>
+                        <Normaltekst tag="div">
+                            <App />
+                        </Normaltekst>
+                    </Router>
+                </UnleashContainer>
+            </Suspense>
+        </Provider>
+    </ErrorBoundary>,
     document.getElementById('root')
 );
 


### PR DESCRIPTION
Motivasjon:
https://logs.adeo.no/app/discover#/doc/96e648c0-980a-11e9-830a-e17bbd64b4db/logstash-apps-prod-005458?id=njHvWoMBuqcZnVFFaly3

Etter inspo fra dekoratørens tilsvarende problemer:
https://github.com/navikt/nav-dekoratoren/commit/ba5e8d850ffb1660573ec305a9c44a9eba1134c3

Feilen ble logget av window.error lytteren til nå, men dette vil fungere som en `try/catch` og re-rendre appen i stedet for å kræsje hvis man bruker dom muterende verktøy e.l.
Tenker det er en fin løsning her da appen ikke er veldig kompleks. 
Ser vi at loggene logger en spesiell feil som er forårsaket av noe i koden vår derimot kan vi endre håndtering av det senere.
Det har jeg hittil ikke sett mye av, kun et sted. Men det var vanskelig å gjenskape og @r154508  tenker det var en bruker med data som var "uvanlig".

Dette kan testes her https://codepen.io/gaearon/pen/wqvxGa?editors=0010 ved å endre fra å vise feilmelding til å re-rendre appen hvis feil oppstår.

Window.error trengs enda da feil som ikke kommer fra react-komponenter vil bli plukket opp her.