### PR TITLE
Feature/pl 5384

### DIFF
--- a/.github/workflows/deploy-dev-fss.yaml
+++ b/.github/workflows/deploy-dev-fss.yaml
@@ -30,10 +30,10 @@ jobs:
           REACT_APP_LOGINSERVICE_URL: "https://pensjon-selvbetjening-opptjening-frontend.dev.adeo.no/pensjon/opptjening/oauth2/internal/login?redirect="
           REACT_APP_OPPTJENING_ENDPOINT: "/api/opptjeningonbehalf"
           REACT_APP_DECORATOR_URL: "https://static-v4-decorator.nais.adeo.no"
-          REACT_APP_DINPENSJON_URL: "https://pensjon-pselv-q2.dev.adeo.no/pselv/publisering/dinpensjon.jsf"
-          REACT_APP_DINEPENSJONSPOENG_URL: "https://pensjon-pselv-q2.dev.adeo.no/pselv/publisering/dinepensjonspoeng.jsf"
-          REACT_APP_PENSJONSKALKULATOR_URL: "https://pensjon-pselv-q2.dev.adeo.no/pselv/simulering.jsf"
-          REACT_APP_OVERFORE_OMSORGSOPPTJENING_URL: "https://pensjon-pselv-q2.dev.adeo.no/pselv/publisering/overforeomsorgspoeng.jsf"
+          REACT_APP_DINPENSJON_URL: "https://pensjon-pselv-q2-gcp.dev.nav.no/pselv/publisering/dinpensjon.jsf"
+          REACT_APP_DINEPENSJONSPOENG_URL: "https://pensjon-pselv-q2-gcp.dev.nav.no/pselv/publisering/dinepensjonspoeng.jsf"
+          REACT_APP_PENSJONSKALKULATOR_URL: "https://pensjon-pselv-q2-gcp.dev.nav.no/pselv/simulering.jsf"
+          REACT_APP_OVERFORE_OMSORGSOPPTJENING_URL: "https://pensjon-pselv-q2-gcp.dev.nav.no/pselv/publisering/overforeomsorgspoeng.jsf"
         run: npm run build
       - name: Build Docker image dev-fss
         run: |

--- a/.github/workflows/deploy-dev-fss.yaml
+++ b/.github/workflows/deploy-dev-fss.yaml
@@ -30,10 +30,10 @@ jobs:
           REACT_APP_LOGINSERVICE_URL: "https://pensjon-selvbetjening-opptjening-frontend.dev.adeo.no/pensjon/opptjening/oauth2/internal/login?redirect="
           REACT_APP_OPPTJENING_ENDPOINT: "/api/opptjeningonbehalf"
           REACT_APP_DECORATOR_URL: "https://static-v4-decorator.nais.adeo.no"
-          REACT_APP_DINPENSJON_URL: "https://pensjon-pselv-q2-gcp.dev.nav.no/pselv/publisering/dinpensjon.jsf"
-          REACT_APP_DINEPENSJONSPOENG_URL: "https://pensjon-pselv-q2-gcp.dev.nav.no/pselv/publisering/dinepensjonspoeng.jsf"
-          REACT_APP_PENSJONSKALKULATOR_URL: "https://pensjon-pselv-q2-gcp.dev.nav.no/pselv/simulering.jsf"
-          REACT_APP_OVERFORE_OMSORGSOPPTJENING_URL: "https://pensjon-pselv-q2-gcp.dev.nav.no/pselv/publisering/overforeomsorgspoeng.jsf"
+          REACT_APP_DINPENSJON_URL: "https://pensjon-pselv-q2.dev.adeo.no/pselv/publisering/dinpensjon.jsf"
+          REACT_APP_DINEPENSJONSPOENG_URL: "https://pensjon-pselv-q2.dev.adeo.no/pselv/publisering/dinepensjonspoeng.jsf"
+          REACT_APP_PENSJONSKALKULATOR_URL: "https://pensjon-pselv-q2.dev.adeo.no/pselv/simulering.jsf"
+          REACT_APP_OVERFORE_OMSORGSOPPTJENING_URL: "https://pensjon-pselv-q2.dev.adeo.no/pselv/publisering/overforeomsorgspoeng.jsf"
         run: npm run build
       - name: Build Docker image dev-fss
         run: |

--- a/.github/workflows/deploy-dev-gcp.yaml
+++ b/.github/workflows/deploy-dev-gcp.yaml
@@ -30,10 +30,10 @@ jobs:
           REACT_APP_LOGINSERVICE_URL: "https://loginservice.dev.nav.no/login?redirect="
           REACT_APP_OPPTJENING_ENDPOINT: "/api/opptjening"
           REACT_APP_DECORATOR_URL: "https://dekoratoren.dev.nav.no"
-          REACT_APP_DINPENSJON_URL: "https://pensjon-pselv-q2.dev.nav.no/pselv/publisering/dinpensjon.jsf"
-          REACT_APP_DINEPENSJONSPOENG_URL: "https://pensjon-pselv-q2.dev.nav.no/pselv/publisering/dinepensjonspoeng.jsf"
-          REACT_APP_PENSJONSKALKULATOR_URL: "https://pensjon-pselv-q2.dev.nav.no/pselv/simulering.jsf"
-          REACT_APP_OVERFORE_OMSORGSOPPTJENING_URL: "https://pensjon-pselv-q2.dev.nav.no/pselv/publisering/overforeomsorgspoeng.jsf"
+          REACT_APP_DINPENSJON_URL: "https://pensjon-pselv-q2-gcp.dev.nav.no/pselv/publisering/dinpensjon.jsf"
+          REACT_APP_DINEPENSJONSPOENG_URL: "https://pensjon-pselv-q2-gcp.dev.nav.no/pselv/publisering/dinepensjonspoeng.jsf"
+          REACT_APP_PENSJONSKALKULATOR_URL: "https://pensjon-pselv-q2-gcp.dev.nav.no/pselv/simulering.jsf"
+          REACT_APP_OVERFORE_OMSORGSOPPTJENING_URL: "https://pensjon-pselv-q2-gcp.dev.nav.no/pselv/publisering/overforeomsorgspoeng.jsf"
         run: npm run build
       - name: Build Docker image dev-gcp
         run: |


### PR DESCRIPTION
Gjorde opprinnelig endringen i både deploy-dev-gcp.yaml og deploy-dev-fss.yaml, men tester indikerte at det bare fungerte i dev-gcp. For fss ble ID-porten-innlogging trigget når man gikk til PSELV GCP.