### PR TITLE
PL-6005 Opprette veileder-app i GCP

### DIFF
--- a/.docker/Dockerfile-gcp
+++ b/.docker/Dockerfile-gcp
@@ -3,4 +3,4 @@ FROM nginxinc/nginx-unprivileged
 COPY /build /usr/share/nginx/html
 
 # Will extract environment variables before nginx starts (ref. https://hub.docker.com/_/nginx):
-COPY nginx/gcp.conf /etc/nginx/templates/default.conf.template
+COPY .nginx/gcp.conf /etc/nginx/templates/default.conf.template

--- a/.docker/Dockerfile-gcp-intern
+++ b/.docker/Dockerfile-gcp-intern
@@ -1,0 +1,6 @@
+FROM nginxinc/nginx-unprivileged
+
+COPY /build /usr/share/nginx/html
+
+# Will extract environment variables before nginx starts (ref. https://hub.docker.com/_/nginx):
+COPY .nginx/gcp-intern.conf /etc/nginx/templates/default.conf.template

--- a/.github/workflows/deploy-dev-gcp-intern.yaml
+++ b/.github/workflows/deploy-dev-gcp-intern.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Deploy internal to dev-gcp
     runs-on: ubuntu-latest
     env:
-      IMAGE_DEV_GCP_INTERN: ghcr.io/${{ github.repository }}/pensjon-selvbetjening-opptjening-frontend-dev-gcp-intern:${{ github.sha }}
+      IMAGE_DEV_GCP_INTERN: ghcr.io/${{ github.repository }}/pensjon-veiledning-opptjening-frontend-dev-gcp:${{ github.sha }}
     steps:
       - name: Use Node.js v12.18.3
         uses: actions/setup-node@v1
@@ -27,7 +27,7 @@ jobs:
         run: npm test -- --watchAll=false
       - name: Build application
         env:
-          REACT_APP_LOGINSERVICE_URL: "https://pensjon-selvbetjening-opptjening-frontend.dev.intern.nav.no/pensjon/opptjening/oauth2/internal/login?redirect="
+          REACT_APP_LOGINSERVICE_URL: "https://pensjon-veiledning-opptjening-frontend.dev.intern.nav.no/pensjon/opptjening/oauth2/internal/login?redirect="
           REACT_APP_OPPTJENING_ENDPOINT: "/api/opptjeningonbehalf"
           REACT_APP_DECORATOR_URL: "https://static-v4-decorator.nais.adeo.no"
           REACT_APP_DINPENSJON_URL: "https://pensjon-pselv-q2.dev.adeo.no/pselv/publisering/dinpensjon.jsf"

--- a/.github/workflows/deploy-dev-gcp.yaml
+++ b/.github/workflows/deploy-dev-gcp.yaml
@@ -1,4 +1,4 @@
-name: NAIS Deploy to dev-gcp
+name: Deploy to dev-gcp
 
 on: workflow_dispatch
 
@@ -37,7 +37,7 @@ jobs:
         run: npm run build
       - name: Build Docker image dev-gcp
         run: |
-          docker build -f Dockerfile-gcp -t ${IMAGE_DEV_GCP} .
+          docker build -f .docker/Dockerfile-gcp -t ${IMAGE_DEV_GCP} .
       - name: Log in to the container registry
         uses: docker/login-action@v1
         with:
@@ -48,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: ./Dockerfile-gcp
+          file: .docker/Dockerfile-gcp
           push: true
           tags: ${{ env.IMAGE_DEV_GCP }}
       - name: Generate NAIS variables dev-gcp

--- a/.github/workflows/deploy-prod-gcp-intern.yaml
+++ b/.github/workflows/deploy-prod-gcp-intern.yaml
@@ -1,0 +1,69 @@
+name: Deploy prod-gcp internal version
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy-to-prod:
+    name: Deploy internal to prod-gcp
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_PROD_GCP-INTERN: ghcr.io/${{ github.repository }}/pensjon-veiledning-opptjening-frontend-prod-gcp:${{ github.sha }}
+    steps:
+      - name: Use Node.js v12.18.3
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.18.3"
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test -- --watchAll=false
+      - name: Build application
+        env:
+          REACT_APP_LOGINSERVICE_URL: "https://pensjon-veiledning-opptjening-frontend.intern.nav.no/pensjon/opptjening/oauth2/internal/login?redirect="
+          REACT_APP_OPPTJENING_ENDPOINT: "/api/opptjeningonbehalf"
+          REACT_APP_DECORATOR_URL: "https://static-v4-decorator.nais.adeo.no"
+          REACT_APP_DINPENSJON_URL: "https://pensjon-pselv.nais.adeo.no/pselv/publisering/dinpensjon.jsf"
+          REACT_APP_DINEPENSJONSPOENG_URL: "https://pensjon-pselv.nais.adeo.no/pselv/publisering/dinepensjonspoeng.jsf"
+          REACT_APP_PENSJONSKALKULATOR_URL: "https://pensjon-pselv.nais.adeo.no/pselv/simulering.jsf"
+          REACT_APP_OVERFORE_OMSORGSOPPTJENING_URL: "https://pensjon-pselv.nais.adeo.no/pselv/publisering/overforeomsorgspoeng.jsf"
+        run: npm run build
+      - name: Build Docker image prod-gcp-intern
+        run: |
+          docker build -f .docker/Dockerfile-gcp-intern -t ${IMAGE_PROD_GCP_INTERN} .
+      - name: Log in to the container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: .docker/Dockerfile-gcp-intern
+          push: true
+          tags: ${{ env.IMAGE_PROD_GCP_INTERN }}
+      - name: Generate NAIS variables prod-gcp-intern
+        run: |
+          cat > .nais/vars-prod-gcp-intern.yaml <<EOF
+          namespace: pensjonselvbetjening
+          image_prod_gcp_intern: $IMAGE_PROD_GCP_INTERN
+          EOF
+      - name: Deploy to prod-gcp-intern
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: .nais/prod-gcp-intern.yml
+          VARS: .nais/vars-prod-gcp-intern.yaml

--- a/.nais/dev-gcp-intern.yml
+++ b/.nais/dev-gcp-intern.yml
@@ -1,0 +1,32 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: pensjon-veiledning-opptjening-frontend
+  namespace: pensjonselvbetjening
+  labels:
+    team: pensjonselvbetjening
+  annotations:
+    nais.io/run-as-user: "101" # nginx
+    nais.io/read-only-file-system: "false" # need write /etc/nginx/conf.d
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+spec:
+  image: {{ image_dev_gcp_intern }}
+  ingresses:
+    - https://pensjon-veiledning-opptjening-frontend.dev.intern.nav.no
+  port: 8080
+  replicas:
+    min: 1
+    max: 1
+  liveness:
+    path: /internal/alive
+    initialDelay: 30
+    timeout: 1
+    periodSeconds: 30
+    failureThreshold: 5
+  readiness:
+    path: /internal/ready
+    initialDelay: 30
+    timeout: 1
+  env:
+    - name: "OPPTJENING_BACKEND"
+      value: "https://pensjon-selvbetjening-opptjening-backend.dev.nav.no"

--- a/.nais/dev-gcp.yml
+++ b/.nais/dev-gcp.yml
@@ -16,13 +16,13 @@ spec:
     min: 1
     max: 1
   liveness:
-    path: "/api/internal/isAlive"
+    path: /internal/alive
     initialDelay: 30
     timeout: 1
     periodSeconds: 30
     failureThreshold: 5
   readiness:
-    path: "/api/internal/isReady"
+    path: /internal/ready
     initialDelay: 30
     timeout: 1
   accessPolicy:

--- a/.nais/prod-gcp-intern.yml
+++ b/.nais/prod-gcp-intern.yml
@@ -1,0 +1,32 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: pensjon-veiledning-opptjening-frontend
+  namespace: pensjonselvbetjening
+  labels:
+    team: pensjonselvbetjening
+  annotations:
+    nais.io/run-as-user: "101" # nginx
+    nais.io/read-only-file-system: "false" # need write /etc/nginx/conf.d
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+spec:
+  image: {{ image_prod_gcp_intern }}
+  ingresses:
+    - https://pensjon-veiledning-opptjening-frontend.intern.nav.no
+  port: 8080
+  replicas:
+    min: 2
+    max: 4
+  liveness:
+    path: /internal/alive
+    initialDelay: 30
+    timeout: 1
+    periodSeconds: 30
+    failureThreshold: 5
+  readiness:
+    path: /internal/ready
+    initialDelay: 30
+    timeout: 1
+  env:
+    - name: "OPPTJENING_BACKEND"
+      value: "https://pensjon-selvbetjening-opptjening-backend.intern.nav.no"

--- a/.nais/prod-gcp.yml
+++ b/.nais/prod-gcp.yml
@@ -16,13 +16,13 @@ spec:
     min: 2
     max: 2
   liveness:
-    path: "/api/internal/isAlive"
+    path: /internal/alive
     initialDelay: 30
     timeout: 1
     periodSeconds: 30
     failureThreshold: 5
   readiness:
-    path: "/api/internal/isReady"
+    path: /internal/ready
     initialDelay: 30
     timeout: 1
   accessPolicy:

--- a/.nginx/gcp-intern.conf
+++ b/.nginx/gcp-intern.conf
@@ -1,0 +1,100 @@
+log_format json escape=json
+  '{'
+    '"level":"INFO",'
+    '"level_value":20000,'
+    '"message":"Received $request",'
+    '"time_local":"$time_local",'
+    '"remote_addr":"$remote_addr",'
+    '"request":"$request",'
+    '"status":$status,'
+    '"body_bytes_sent":$body_bytes_sent,'
+    '"request_time":$request_time,'
+    '"http_referrer":"$http_referer",'
+    '"http_user_agent":"$http_user_agent"'
+  '}';
+
+log_format json_no_pid escape=json
+  '{'
+    '"level":"INFO",'
+    '"level_value":20000,'
+    '"message":"Received $no_pid_request",'
+    '"time_local":"$time_local",'
+    '"remote_addr":"$remote_addr",'
+    '"request":"$no_pid_request",'
+    '"status":$status,'
+    '"body_bytes_sent":$body_bytes_sent,'
+    '"request_time":$request_time,'
+    '"http_referrer":"$no_pid_referer",'
+    '"http_user_agent":"$http_user_agent"'
+  '}';
+
+server {
+    listen 8080;
+    server_tokens off;
+    root /usr/share/nginx/html;
+    port_in_redirect off;
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml;
+    gzip_comp_level 9;
+    etag on;
+    large_client_header_buffers 4 32k;
+    index index.html index.htm;
+
+    location / {
+        set $no_pid_request $request;
+        set $no_pid_referer $http_referer;
+
+        if ($no_pid_request ~ (.*)(fnr|pid)=[^&]*(.*)) {
+            set $no_pid_request $1$2=***********$3;
+        }
+
+        if ($no_pid_referer ~ (.*)(fnr|pid)=[^&]*(.*)) {
+            set $no_pid_referer $1$2=***********$3;
+        }
+
+        access_log /var/log/nginx/access.log json_no_pid;
+    }
+
+    location /pensjon/opptjening/ {
+        alias /usr/share/nginx/html/;
+        try_files $uri /index.html;
+    }
+
+    location /pensjon/opptjening/api/ {
+        set $no_pid_request $request;
+        set $no_pid_referer $http_referer;
+
+        if ($no_pid_request ~ (.*)(fnr|pid)=[^&]*(.*)) {
+            set $no_pid_request $1$2=***********$3;
+        }
+
+        if ($no_pid_referer ~ (.*)(fnr|pid)=[^&]*(.*)) {
+            set $no_pid_referer $1$2=***********$3;
+        }
+
+        access_log /var/log/nginx/access.log json_no_pid;
+        proxy_pass "${OPPTJENING_BACKEND}/api/";
+        proxy_ssl_server_name on;
+    }
+
+    location /pensjon/opptjening/oauth2/ {
+        access_log /var/log/nginx/access.log json;
+        proxy_pass "${OPPTJENING_BACKEND}/oauth2/";
+        proxy_ssl_server_name on;
+        proxy_buffer_size          128k;
+        proxy_buffers              4 256k;
+        proxy_busy_buffers_size    256k;
+    }
+
+    location = /internal/alive {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200;
+    }
+
+    location = /internal/ready {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200;
+    }
+}

--- a/.nginx/gcp.conf
+++ b/.nginx/gcp.conf
@@ -49,13 +49,13 @@ server {
         proxy_busy_buffers_size    256k;
     }
 
-    location = /api/internal/isAlive {
+    location = /internal/alive {
         access_log off;
         add_header Content-Type text/plain;
         return 200;
     }
 
-    location = /api/internal/isReady {
+    location = /internal/ready {
         access_log off;
         add_header Content-Type text/plain;
         return 200;


### PR DESCRIPTION
Denne PR deployer veileder-varianten av frontend i GCP. Denne skal erstatte varianten av frontend som ligger i FSS (men beholder FSS-varianten inntil GCP-varianten er testet).

Det ble gjort en forberedende commit (ny workflow) for å få testet branchen: bf02655bca895c770a6e941f75252c82c43651c1

I motsetning til AP-søknad-appen er det ikke er noe logikk i Opptjening-frontend for å skille mellom eksterne og interne brukere (skillet gjøres utelukkende via konfigurasjon). Dette anser jeg som en fordel, da vi ikke ønsker slik logikk i koden. Ulempen er at det må deployes to varianter av frontend i GCP (én med innbygger-konfig og én med veileder-konfig).

- Innbygger-/selvbetjening-varianten kalles `pensjon-selvbetjening-opptjening-frontend` (som før)
- Veileder-varianten kalles `pensjon-veiledning-opptjening-frontend`

Ellers er `Dockerfile`-filene nå samlet i en `.docker`-mappe, og `nginx`-mappa er omdøpt til `.nginx` (for å få en gjennomført "dot file"-struktur). FSS-filene er ikke flyttet, da de uansett skal slettes når GCP-varianten er testet ferdig.

Helsesjekk-endepunktene er endret til å bli mer NAV-standard.
