### PR TITLE
PL-6007 Enable Wonderwall

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yaml
+++ b/.github/workflows/deploy-dev-gcp.yaml
@@ -27,7 +27,7 @@ jobs:
         run: npm test -- --watchAll=false
       - name: Build application
         env:
-          REACT_APP_LOGINSERVICE_URL: "https://loginservice.dev.nav.no/login?redirect="
+          REACT_APP_LOGINSERVICE_URL: "not used in GCP"
           REACT_APP_OPPTJENING_ENDPOINT: "/api/opptjening"
           REACT_APP_DECORATOR_URL: "https://dekoratoren.dev.nav.no"
           REACT_APP_DINPENSJON_URL: "https://pensjon-pselv-q2-gcp.dev.nav.no/pselv/publisering/dinpensjon.jsf"

--- a/.github/workflows/deploy-prod-gcp.yaml
+++ b/.github/workflows/deploy-prod-gcp.yaml
@@ -30,7 +30,7 @@ jobs:
         run: npm test -- --watchAll=false
       - name: Build application
         env:
-          REACT_APP_LOGINSERVICE_URL: "https://loginservice.nav.no/login?redirect="
+          REACT_APP_LOGINSERVICE_URL: "not used in GCP"
           REACT_APP_OPPTJENING_ENDPOINT: "/api/opptjening"
           REACT_APP_DECORATOR_URL: "https://www.nav.no/dekoratoren"
           REACT_APP_DINPENSJON_URL: "https://www.nav.no/pselv/publisering/dinpensjon.jsf"

--- a/.nais/dev-gcp.yml
+++ b/.nais/dev-gcp.yml
@@ -12,7 +12,6 @@ metadata:
 spec:
   image: {{ image_dev_gcp }}
   ingresses:
-    - https://pensjon-selvbetjening-opptjening-frontend.dev.nav.no
     - https://www-gcp.dev.nav.no/pensjon/opptjening
   port: 8080
   replicas:
@@ -30,7 +29,7 @@ spec:
     timeout: 1
   idporten:
     enabled: true
-    clientURI: https://pensjon-selvbetjening-opptjening-frontend.dev.nav.no/pensjon/opptjening
+    clientURI: https://www-gcp.dev.nav.no/pensjon/opptjening
     redirectPath: "/oauth2/callback"
     frontchannelLogoutPath: "/logout"
     postLogoutRedirectURIs:

--- a/.nais/dev-gcp.yml
+++ b/.nais/dev-gcp.yml
@@ -28,6 +28,9 @@ spec:
     path: /internal/ready
     initialDelay: 30
     timeout: 1
+  idporten:
+    sidecar:
+      autoLogin: true
   accessPolicy:
     outbound:
       rules:

--- a/.nais/dev-gcp.yml
+++ b/.nais/dev-gcp.yml
@@ -33,7 +33,7 @@ spec:
       enabled: true
       autoLogin: true
       autoLoginIgnorePaths:
-        - /api/status
+        - /pensjon/opptjening/api/status
         - /internal/ping
         - /internal/selftest
   accessPolicy:

--- a/.nais/dev-gcp.yml
+++ b/.nais/dev-gcp.yml
@@ -29,7 +29,14 @@ spec:
     initialDelay: 30
     timeout: 1
   idporten:
+    enabled: true
+    clientURI: https://pensjon-selvbetjening-opptjening-frontend.dev.nav.no/pensjon/opptjening
+    redirectPath: "/oauth2/callback"
+    frontchannelLogoutPath: "/logout"
+    postLogoutRedirectURIs:
+      - "https://www.nav.no"
     sidecar:
+      enabled: true
       autoLogin: true
   accessPolicy:
     outbound:

--- a/.nais/dev-gcp.yml
+++ b/.nais/dev-gcp.yml
@@ -29,14 +29,13 @@ spec:
     timeout: 1
   idporten:
     enabled: true
-    clientURI: https://www-gcp.dev.nav.no/pensjon/opptjening
-    redirectPath: "/oauth2/callback"
-    frontchannelLogoutPath: "/logout"
-    postLogoutRedirectURIs:
-      - "https://www.nav.no"
     sidecar:
       enabled: true
       autoLogin: true
+      autoLoginIgnorePaths:
+        - /api/status
+        - /internal/ping
+        - /internal/selftest
   accessPolicy:
     outbound:
       rules:

--- a/.nais/dev-gcp.yml
+++ b/.nais/dev-gcp.yml
@@ -33,9 +33,9 @@ spec:
       enabled: true
       autoLogin: true
       autoLoginIgnorePaths:
-        - /pensjon/opptjening/api/status
         - /internal/ping
         - /internal/selftest
+        - /pensjon/opptjening/api/status
   accessPolicy:
     outbound:
       rules:

--- a/.nais/prod-gcp.yml
+++ b/.nais/prod-gcp.yml
@@ -12,7 +12,6 @@ metadata:
 spec:
   image: {{ image_prod_gcp }}
   ingresses:
-    - https://pensjon-selvbetjening-opptjening-frontend.intern.nav.no
     - https://www.nav.no/pensjon/opptjening
   port: 8080
   replicas:
@@ -28,6 +27,15 @@ spec:
     path: /internal/ready
     initialDelay: 30
     timeout: 1
+  idporten:
+    enabled: true
+    sidecar:
+      enabled: true
+      autoLogin: true
+      autoLoginIgnorePaths:
+        - /internal/ping
+        - /internal/selftest
+        - /pensjon/opptjening/api/status
   accessPolicy:
     outbound:
       rules:

--- a/src/components/elements/LoginPanel/LoginPanel.adoc
+++ b/src/components/elements/LoginPanel/LoginPanel.adoc
@@ -1,5 +1,5 @@
 ==== LoginPanel
-Panel med knapp for å logge inn via LOGINSERVICE.
+Panel med knapp for å logge inn.
 
 ===== LoginPanel.js
 |===


### PR DESCRIPTION
Erstatter bruk av [loginservice](https://github.com/navikt/loginservice) (som skal fases ut) med bruk av [Wonderwall](https://doc.nais.io/appendix/wonderwall/) (NAIS-[sidecar](https://www.nginx.com/resources/glossary/sidecar/) for innlogging via ID-porten).

NB: Med `idporten: enabled: true` tillates appen å bare ha én enkelt ingress.