### PR TITLE
Fjern feil autoformatering av {{ image }}

### DIFF
--- a/.nais/dev-gcp.yml
+++ b/.nais/dev-gcp.yml
@@ -10,7 +10,7 @@ metadata:
     nais.io/read-only-file-system: "false" # need write /etc/nginx/conf.d
     nginx.ingress.kubernetes.io/proxy-buffer-size: "64k"
 spec:
-  image: { { image } }
+  image: {{ image }}
   ingresses:
     - https://www-gcp.intern.dev.nav.no/pensjon/opptjening
     - https://www-gcp.ansatt.dev.nav.no/pensjon/opptjening

--- a/.nais/prod-gcp.yml
+++ b/.nais/prod-gcp.yml
@@ -10,7 +10,7 @@ metadata:
     nais.io/read-only-file-system: "false" # need write /etc/nginx/conf.d
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
 spec:
-  image: { { image } }
+  image: {{ image }}
   ingresses:
     - https://www.nav.no/pensjon/opptjening
   port: 8080


### PR DESCRIPTION
- **PEB-860: Åpne opp for alle å laste /static ressurser. Dette er slik at skjermdeling på nav.no skal fungere igjen**
- **Fjern feil autoformatering**
