### PR TITLE
Update FAQ

### DIFF
--- a/public/locales/en/faq_born_after_1962.json
+++ b/public/locales/en/faq_born_after_1962.json
@@ -1,5 +1,5 @@
 {
-    "faq-number-of-questions": 10,
+    "faq-number-of-questions": 8,
 
     "faq-question-1": "What does 'pension reserves' mean?",
     "faq-answer-1": [
@@ -18,26 +18,20 @@
         "Annual income is included from 1 January the year after the final tax assessment has been completed. For example, your income for 2016 is included in the pension calculation from 1 January 2018."
     ],
 
-    "faq-question-4": "How did the 2010 pension reform affect my pension reserves?",
-    "faq-answer-4": "Your pension reserve was established with effect from 1 January 2010 in connection with the entry into force of the pension reform. On that date, the pension earnings you had had in the calendar years up to and including 2008 (the last year for which the tax assessment had been completed) were added up to form a reserve.",
+    "faq-question-4": "How are pension earnings from unemployment benefit calculated?",
+    "faq-answer-4": "For periods where you receive unemployment benefit, 18.1 per cent of the income that was used as the basis for calculating unemployment benefit is added to your pension reserves.",
 
-    "faq-question-5": "How are pension earnings from unemployment benefit calculated?",
-    "faq-answer-5": "For periods where you receive unemployment benefit, 18.1 per cent of the income that was used as the basis for calculating unemployment benefit is added to your pension reserves.",
+    "faq-question-5": "How are pension earnings from disability benefit calculated?",
+    "faq-answer-5": "For periods where you receive disability benefit, 18.1 per cent of your assumed income is added to your pension reserves. This applies up to and including the year you turn 61.",
 
-    "faq-question-6": "How are pension earnings from disability benefit calculated?",
-    "faq-answer-6": "For periods where you receive disability benefit, 18.1 per cent of your assumed income is added to your pension reserves. This applies up to and including the year you turn 61.",
+    "faq-question-6": "How are pension earnings from compulsory military service calculated?",
+    "faq-answer-6": "You can also receive pension earnings towards your pension reserves from compulsory military service that was started at the earliest in 2010. The earnings you receive are 18.1 per cent of the National Insurance Scheme’s basic amount (G).",
 
-    "faq-question-7": "How are pension earnings from compulsory military service calculated?",
-    "faq-answer-7": "You can also receive pension earnings towards your pension reserves from compulsory military service that was started at the earliest in 2010. The earnings you receive are 18.1 per cent of the National Insurance Scheme’s basic amount (G).",
+    "faq-question-7": "Why do I not have any pension reserves?",
+    "faq-answer-7": "No earned pension has been registered. Nav receives information about your pensionable income from the Norwegian Tax Administration. If you think there is something wrong with your registered income, contact the [Norwegian Tax Administration](https://www.skatteetaten.no/)",
 
-    "faq-question-8": "Why do I not have any pension reserves?",
-    "faq-answer-8": "No earned pension has been registered. Nav receives information about your pensionable income from the Norwegian Tax Administration. If you think there is something wrong with your registered income, contact your [local tax office](https://www.skatteetaten.no/)",
-
-    "faq-question-9": "What does ‘no basis’ mean?",
-    "faq-answer-9": "We receive information about your pensionable income from the Norwegian Tax Administration once the tax settlement is ready. Until the tax settlement for a year has been completed, a text saying ‘No basis’ will be displayed.",
-
-    "faq-question-10": "What are pension earnings for care work?",
-    "faq-answer-10": [
+    "faq-question-8": "What are pension earnings for care work?",
+    "faq-answer-8": [
         "Pension earnings for care work is not extra pay that you receive from the National Insurance Scheme, rather it is a scheme to ensure you get a higher pension when you start drawing a pension. You must be a member of the Norwegian National Insurance Scheme during the period of care in order to be entitled to pension earnings for care work.",
         "The pension earnings for care work scheme was introduced in 1992 and has since been expanded such that people with children born before 1992 can also receive these pension earnings. See the more detailed explanation below."
     ]}

--- a/public/locales/en/faq_born_in_or_between_1954_and_1962.json
+++ b/public/locales/en/faq_born_in_or_between_1954_and_1962.json
@@ -1,5 +1,5 @@
 {
-    "faq-number-of-questions": 11,
+    "faq-number-of-questions": 9,
 
     "faq-question-1": "What does 'pension reserves' mean?",
     "faq-answer-1": [
@@ -18,29 +18,23 @@
         "Annual income is included from 1 January the year after the final tax assessment has been completed. For example, your income for 2016 is included in the pension calculation from 1 January 2018."
     ],
 
-    "faq-question-4": "How did the 2010 pension reform affect my pension reserves?",
-    "faq-answer-4": "Your pension reserve was established with effect from 1 January 2010 in connection with the entry into force of the pension reform. On that date, the pension earnings you had had in the calendar years up to and including 2008 (the last year for which the tax assessment had been completed) were added up to form a reserve.",
+    "faq-question-4": "How are pension earnings from unemployment benefit calculated?",
+    "faq-answer-4": "For periods where you receive unemployment benefit, 18.1 per cent of the income that was used as the basis for calculating unemployment benefit is added to your pension reserves.",
 
-    "faq-question-5": "How are pension earnings from unemployment benefit calculated?",
-    "faq-answer-5": "For periods where you receive unemployment benefit, 18.1 per cent of the income that was used as the basis for calculating unemployment benefit is added to your pension reserves.",
+    "faq-question-5": "How are pension earnings from disability benefit calculated?",
+    "faq-answer-5": "We calculate your retirement pension partly based on your pension balance and partly on your pension points.",
 
-    "faq-question-6": "How are pension earnings from disability benefit calculated?",
-    "faq-answer-6": "For periods where you receive disability benefit, 18.1 per cent of your assumed income is added to your pension reserves. This applies up to and including the year you turn 61.",
+    "faq-question-6": "How are pension earnings from compulsory military service calculated?",
+    "faq-answer-6": "You can also receive pension earnings towards your pension reserves from compulsory military service that was started at the earliest in 2010. The earnings you receive are 18.1 per cent of the National Insurance Scheme’s basic amount (G).",
 
-    "faq-question-7": "How are pension earnings from compulsory military service calculated?",
-    "faq-answer-7": "You can also receive pension earnings towards your pension reserves from compulsory military service that was started at the earliest in 2010. The earnings you receive are 18.1 per cent of the National Insurance Scheme’s basic amount (G).",
+    "faq-question-7": "Why do I not have any pension reserves?",
+    "faq-answer-7": "No pension earnings or pension points have been registered. Nav receives information about your pensionable income from the Norwegian Tax Administration. If you think there is something wrong with your registered income, contact the [Norwegian Tax Administration](https://www.skatteetaten.no/)",
 
-    "faq-question-8": "Why do I not have any pension reserves?",
-    "faq-answer-8": "No pension earnings or pension points have been registered. Nav receives information about your pensionable income from the Norwegian Tax Administration. If you think there is something wrong with your registered income, contact your [local tax office](https://www.skatteetaten.no/)",
+    "faq-question-8": "Pension earnings for people born between 1954 and 1962",
+    "faq-answer-8": "You can earn a pension from the year you turn 17 until the year you turn 75. People born in the period 1954–1962 earn their old age pension according to a combination of both the old rules and the new rules in the National Insurance Act. This means that their pension rights are earned through both pension points and their pension reserves.",
 
-    "faq-question-9": "What does ‘no basis’ mean?",
-    "faq-answer-9": "We receive information about your pensionable income from the Norwegian Tax Administration once the tax settlement is ready. Until the tax settlement for a year has been completed, a text saying ‘No basis’ will be displayed.",
-
-    "faq-question-10": "Pension earnings for people born between 1954 and 1962",
-    "faq-answer-10": "You can earn a pension from the year you turn 17 until the year you turn 75. People born in the period 1954–1962 earn their old age pension according to a combination of both the old rules and the new rules in the National Insurance Act. This means that their pension rights are earned through both pension points and their pension reserves.",
-
-    "faq-question-11": "What are pension earnings for care work?",
-    "faq-answer-11": [
+    "faq-question-9": "What are pension earnings for care work?",
+    "faq-answer-9": [
         "Pension earnings for care work is not extra pay that you receive from the National Insurance Scheme, rather it is a scheme to ensure you get a higher pension when you start drawing a pension. You must be a member of the Norwegian National Insurance Scheme during the period of care in order to be entitled to pension earnings for care work.",
         "The pension earnings for care work scheme was introduced in 1992 and has since been expanded such that people with children born before 1992 can also receive these pension earnings. See the more detailed explanation below."
     ]

--- a/public/locales/nb/faq_born_after_1962.json
+++ b/public/locales/nb/faq_born_after_1962.json
@@ -1,5 +1,5 @@
 {
-    "faq-number-of-questions": 10,
+    "faq-number-of-questions": 8,
 
     "faq-question-1": "Hva er pensjonsbeholdning?",
     "faq-answer-1": [
@@ -18,26 +18,20 @@
         "Årlig inntekt blir medregnet fra 1. januar året etter at fastsettingen er ferdig. Det betyr for eksempel at inntekten for 2016 først blir medregnet i pensjonen fra 1. januar 2018."
     ],
 
-    "faq-question-4": "Hvordan påvirket pensjonsreformen 2010 beholdningen min?",
-    "faq-answer-4": "Pensjonsbeholdningen din ble etablert med virkning 1. januar 2010 i forbindelse med at pensjonsreformen trådte i kraft. Da ble den opptjeningen du hadde i kalenderår frem til og med 2008 (siste ferdiglignede år) summert til en beholdningsstørrelse.",
+    "faq-question-4": "Hvordan beregnes opptjening for dagpenger?",
+    "faq-answer-4": "For perioder med dagpenger blir 18,1 prosent av en inntekt som er lagt til grunn for fastsettelse av dagpenger lagt til pensjonsbeholdningen din.",
 
-    "faq-question-5": "Hvordan beregnes opptjening for dagpenger?",
-    "faq-answer-5": "For perioder med dagpenger blir 18,1 prosent av en inntekt som er lagt til grunn for fastsettelse av dagpenger lagt til pensjonsbeholdningen din.",
+    "faq-question-5": "Hvordan beregnes opptjening for uføretrygd?",
+    "faq-answer-5": "For perioder med uføretrygd blir 18,1 prosent av en antatt inntekt lagt til pensjonsbeholdningen din. Dette gjelder til og med det året du fyller 61 år.",
 
-    "faq-question-6": "Hvordan beregnes opptjening for uføretrygd?",
-    "faq-answer-6": "For perioder med uføretrygd blir 18,1 prosent av en antatt inntekt lagt til pensjonsbeholdningen din. Dette gjelder til og med det året du fyller 61 år.",
+    "faq-question-6": "Hvordan beregnes opptjening for førstegangstjeneste?",
+    "faq-answer-6": "Førstegangstjeneste på minst 6 måneder i 2010 eller senere kan gi rett til opptjening. 12 måneders tjenestetid gir opptjening på 18,1 prosent av 2,5 G. Kortere tjenestetid gir opptjening for hver påbegynte måned.",
 
-    "faq-question-7": "Hvordan beregnes opptjening for førstegangstjeneste?",
-    "faq-answer-7": "Førstegangstjeneste på minst 6 måneder i 2010 eller senere kan gi rett til opptjening. 12 måneders tjenestetid gir opptjening på 18,1 prosent av 2,5 G. Kortere tjenestetid gir opptjening for hver påbegynte måned.",
+    "faq-question-7": "Hvorfor har jeg ikke pensjonsbeholdning?",
+    "faq-answer-7": "Det er ikke registrert pensjonsopptjening. Nav mottar den pensjonsgivende inntekten fra Skatteetaten. Hvis du mener noe er feil med inntekten må du kontakte [Skatteetaten](https://www.skatteetaten.no/)",
 
-    "faq-question-8": "Hvorfor har jeg ikke pensjonsbeholdning?",
-    "faq-answer-8": "Det er ikke registrert pensjonsopptjening. Nav mottar den pensjonsgivende inntekten fra Skatteetaten. Hvis du mener noe er feil med inntekten må du kontakte ditt [lokale skattekontor](https://www.skatteetaten.no/)",
-
-    "faq-question-9": "Hva betyr 'ikke noe grunnlag'?",
-    "faq-answer-9": "Vi mottar pensjonsgivende inntekt fra Skatteetaten når skatteoppgjøret er klart. Fram til skatteoppgjøret er klart vil det vises en tekst som sier 'Ikke noe grunnlag'.",
-
-    "faq-question-10": "Hva er omsorgsopptjening?",
-    "faq-answer-10": [
+    "faq-question-8": "Hva er omsorgsopptjening?",
+    "faq-answer-8": [
         "Omsorgsopptjening er ikke en ekstra lønn som du får utbetalt fra folketrygden, men en ordning som bidrar til at du kan få høyere pensjon når du blir pensjonist. Du må være medlem i folketrygden i omsorgsperioden for å ha rett til omsorgsopptjening.",
         "Ordningen med omsorgsopptjening ble innført i 1992, og er senere utvidet slik at personer med barn født før 1992 kan få denne opptjeningen. Se mer forklaring under her."
     ]

--- a/public/locales/nb/faq_born_in_or_between_1954_and_1962.json
+++ b/public/locales/nb/faq_born_in_or_between_1954_and_1962.json
@@ -1,5 +1,5 @@
 {
-    "faq-number-of-questions": 11,
+    "faq-number-of-questions": 9,
 
     "faq-question-1": "Hva er pensjonsbeholdning?",
     "faq-answer-1": [
@@ -18,29 +18,23 @@
         "Årlig inntekt blir medregnet fra 1. januar året etter at fastsettingen er ferdig. Det betyr for eksempel at inntekten for 2016 først blir medregnet i pensjonen fra 1. januar 2018."
     ],
 
-    "faq-question-4": "Hvordan påvirket pensjonsreformen 2010 beholdningen min?",
-    "faq-answer-4": "Pensjonsbeholdningen din ble etablert med virkning 1. januar 2010 i forbindelse med at pensjonsreformen trådte i kraft. Da ble den opptjeningen du hadde i kalenderår frem til og med 2008 (siste ferdiglignede år) summert til en beholdningsstørrelse.",
+    "faq-question-4": "Hvordan beregnes opptjening for dagpenger?",
+    "faq-answer-4": "For perioder med dagpenger blir 18,1 prosent av en inntekt som er lagt til grunn for fastsettelse av dagpenger lagt til pensjonsbeholdningen din.",
 
-    "faq-question-5": "Hvordan beregnes opptjening for dagpenger?",
-    "faq-answer-5": "For perioder med dagpenger blir 18,1 prosent av en inntekt som er lagt til grunn for fastsettelse av dagpenger lagt til pensjonsbeholdningen din.",
+    "faq-question-5": "Hvordan beregnes opptjening for uføretrygd?",
+    "faq-answer-5": "Vi beregner alderspensjonen din dels på grunnlag av pensjonsbeholdningen din og dels på grunnlag av pensjonspoeng.",
 
-    "faq-question-6": "Hvordan beregnes opptjening for uføretrygd?",
-    "faq-answer-6": "For perioder med uføretrygd blir 18,1 prosent av en antatt inntekt lagt til pensjonsbeholdningen din. Dette gjelder til og med det året du fyller 61 år.",
+    "faq-question-6": "Hvordan beregnes opptjening for førstegangstjeneste?",
+    "faq-answer-6": "Førstegangstjeneste på minst 6 måneder i 2010 eller senere kan gi rett til opptjening. 12 måneders tjenestetid gir opptjening på 18,1 prosent av 2,5 G. Kortere tjenestetid gir opptjening for hver påbegynte måned.",
 
-    "faq-question-7": "Hvordan beregnes opptjening for førstegangstjeneste?",
-    "faq-answer-7": "Førstegangstjeneste på minst 6 måneder i 2010 eller senere kan gi rett til opptjening. 12 måneders tjenestetid gir opptjening på 18,1 prosent av 2,5 G. Kortere tjenestetid gir opptjening for hver påbegynte måned.",
+    "faq-question-7": "Hvorfor har jeg ikke pensjonsbeholdning?",
+    "faq-answer-7": "Det er ikke registrert pensjonsopptjening eller pensjonspoeng. Nav mottar den pensjonsgivende inntekten fra Skatteetaten. Hvis du mener noe er feil med inntekten må du kontakte [Skatteetaten](https://www.skatteetaten.no/)",
 
-    "faq-question-8": "Hvorfor har jeg ikke pensjonsbeholdning?",
-    "faq-answer-8": "Det er ikke registrert pensjonsopptjening eller pensjonspoeng. Nav mottar den pensjonsgivende inntekten fra Skatteetaten. Hvis du mener noe er feil med inntekten må du kontakte ditt [lokale skattekontor](https://www.skatteetaten.no/)",
+    "faq-question-8": "Pensjonsopptjening for deg som er født mellom 1954-1962",
+    "faq-answer-8": "Det kan tjenes opp pensjonsrettigheter fra det året man fylte 17 år og til og med det året man fyller 75 år. De som er født i perioden 1954-1962 tjener opp til alderspensjonen etter gamle og nye regler i folketrygdloven. Det betyr at man tjener opp pensjonsrettigheter både gjennom pensjonspoeng og en pensjonsbeholdning.",
 
-    "faq-question-9": "Hva betyr 'ikke noe grunnlag'?",
-    "faq-answer-9": "Vi mottar pensjonsgivende inntekt fra Skatteetaten når skatteoppgjøret er klart. Fram til skatteoppgjøret er klart vil det vises en tekst som sier 'Ikke noe grunnlag'.",
-
-    "faq-question-10": "Pensjonsopptjening for deg som er født mellom 1954-1962",
-    "faq-answer-10": "Det kan tjenes opp pensjonsrettigheter fra det året man fylte 17 år og til og med det året man fyller 75 år. De som er født i perioden 1954-1962 tjener opp til alderspensjonen etter gamle og nye regler i folketrygdloven. Det betyr at man tjener opp pensjonsrettigheter både gjennom pensjonspoeng og en pensjonsbeholdning.",
-
-    "faq-question-11": "Hva er omsorgsopptjening?",
-    "faq-answer-11": [
+    "faq-question-9": "Hva er omsorgsopptjening?",
+    "faq-answer-9": [
         "Omsorgsopptjening er ikke en ekstra lønn som du får utbetalt fra folketrygden, men en ordning som bidrar til at du kan få høyere pensjon når du blir pensjonist. Du må være medlem i folketrygden i omsorgsperioden for å ha rett til omsorgsopptjening.",
         "Ordningen med omsorgsopptjening ble innført i 1992, og er senere utvidet slik at personer med barn født før 1992 kan få denne opptjeningen. Se mer forklaring under her."
     ]

--- a/public/locales/nn/faq_born_after_1962.json
+++ b/public/locales/nn/faq_born_after_1962.json
@@ -1,5 +1,5 @@
 {
-    "faq-number-of-questions": 10,
+    "faq-number-of-questions": 8,
 
     "faq-question-1": "Kva er pensjonsbehaldning?",
     "faq-answer-1": [
@@ -18,26 +18,20 @@
         "Årleg inntekt blir medrekna frå 1. januar året etter at fastsetjinga er ferdig. Det betyr for eksempel at inntekta for 2016 først blir rekna med i pensjonen frå 1. januar 2018."
     ],
 
-    "faq-question-4": "Korleis påverka pensjonsreforma 2010 behaldninga mi?",
-    "faq-answer-4": "Pensjonsbehaldninga di blei etablert med verknad 1. januar 2010 i samband med at pensjonsreforma blei sett i verk. Då blei den oppteninga du hadde i kalenderår fram til og med 2008 (siste ferdiglikna år), summert til éin behaldningsstorleik.",
+    "faq-question-4": "Korleis blir oppteninga for dagpengar berekna?",
+    "faq-answer-4": "For periodar med dagpengar blir 18,1 prosent av ei inntekt som er lagd til grunn for fastsetjinga av dagpengane, lagde til pensjonsbehaldninga di.",
 
-    "faq-question-5": "Korleis blir oppteninga for dagpengar berekna?",
-    "faq-answer-5": "For periodar med dagpengar blir 18,1 prosent av ei inntekt som er lagd til grunn for fastsetjinga av dagpengane, lagde til pensjonsbehaldninga di.",
+    "faq-question-5": "Korleis blir oppteninga for uføretrygd berekna?",
+    "faq-answer-5": "For periodar med uføretrygd blir 18,1 prosent av ei anteken inntekt lagde til pensjonsbehaldninga di. Dette gjeld til og med det året du fyller 61 år.",
 
-    "faq-question-6": "Korleis blir oppteninga for uføretrygd berekna?",
-    "faq-answer-6": "For periodar med uføretrygd blir 18,1 prosent av ei anteken inntekt lagde til pensjonsbehaldninga di. Dette gjeld til og med det året du fyller 61 år.",
+    "faq-question-6": "Korleis blir oppteninga for førstegongsteneste berekna?",
+    "faq-answer-6": "Du kan også få opptening til pensjonsbehaldninga basert på førstegongsteneste som du tok til på tidlegast i 2010. Oppteninga utgjer 18,1 prosent av grunnbeløpet i folketrygda (G).",
 
-    "faq-question-7": "Korleis blir oppteninga for førstegongsteneste berekna?",
-    "faq-answer-7": "Du kan også få opptening til pensjonsbehaldninga basert på førstegongsteneste som du tok til på tidlegast i 2010. Oppteninga utgjer 18,1 prosent av grunnbeløpet i folketrygda (G).",
+    "faq-question-7": "Kvifor har eg ikkje pensjonsbehaldning?",
+    "faq-answer-7": "Det er ikkje registrert pensjonsopptening. Nav får den pensjonsgivande inntekta frå Skatteetaten. Dersom du meiner noko er feil med inntekta, må du kontakte [Skatteetaten](https://www.skatteetaten.no/).",
 
-    "faq-question-8": "Kvifor har eg ikkje pensjonsbehaldning?",
-    "faq-answer-8": "Det er ikkje registrert pensjonsopptening. Nav får den pensjonsgivande inntekta frå Skatteetaten. Dersom du meiner noko er feil med inntekta, må du kontakte [det lokale skattekontoret] ditt (https://www.skatteetaten.no/).",
-
-    "faq-question-9": "Kva betyr 'ikkje noko grunnlag'?",
-    "faq-answer-9": "Vi får pensjonsgivande inntekt frå Skatteetaten når skatteoppgjeret er klart. Fram til skatteoppgjeret er klart vil det visast ein tekst som seier 'ikkje noko grunnlag'.",
-
-    "faq-question-10": "Kva er omsorgsopptening?",
-    "faq-answer-10": [
+    "faq-question-8": "Kva er omsorgsopptening?",
+    "faq-answer-8": [
         "Omsorgsopptening er ikkje ei ekstra lønn som du får betalt ut frå folketrygda, men ei ordning som bidreg til at du kan få høgare pensjon når du blir pensjonist. Du må vere medlem i folketrygda i omsorgsperioden for å ha rett til omsorgsopptening.",
         "Ordninga med omsorgsopptening blei innført i 1992, og er seinare utvida slik at personar med barn fødde før 1992 kan få denne oppteninga. Sjå meir forklaring under her."
     ]

--- a/public/locales/nn/faq_born_in_or_between_1954_and_1962.json
+++ b/public/locales/nn/faq_born_in_or_between_1954_and_1962.json
@@ -1,5 +1,5 @@
 {
-    "faq-number-of-questions": 11,
+    "faq-number-of-questions": 9,
 
     "faq-question-1": "Kva er pensjonsbehaldning?",
     "faq-answer-1": [
@@ -18,29 +18,23 @@
         "Årleg inntekt blir rekna med frå 1. januar året etter at fastsetjinga er ferdig. Det betyr for eksempel at inntekta for 2016 først blir rekna med i pensjonen frå 1. januar 2018."
     ],
 
-    "faq-question-4": "Korleis påverka pensjonsreforma 2010 behaldninga mi?",
-    "faq-answer-4": "Pensjonsbehaldninga di blei etablert med verknad 1. januar 2010 i samband med at pensjonsreforma blei sett i verk. Då blei den oppteninga du hadde i kalenderår fram til og med 2008 (siste ferdiglikna år) summert til éin behaldningsstorleik.",
+    "faq-question-4": "Korleis blir oppteninga for dagpengar berekna?",
+    "faq-answer-4": "For periodar med dagpengar blir 18,1 prosent av ei inntekt som er lagd til grunn for fastsetjinga av dagpengane, lagd til pensjonsbehaldninga di.",
 
-    "faq-question-5": "Korleis blir oppteninga for dagpengar berekna?",
-    "faq-answer-5": "For periodar med dagpengar blir 18,1 prosent av ei inntekt som er lagd til grunn for fastsetjinga av dagpengane, lagd til pensjonsbehaldninga di.",
+    "faq-question-5": "Korleis blir oppteninga for uføretrygd berekna?",
+    "faq-answer-5": "Vi bereknar alderspensjonen din dels på grunnlag av pensjonsbehaldninga di og dels på grunnlag av pensjonspoeng.",
 
-    "faq-question-6": "Korleis blir oppteninga for uføretrygd berekna?",
-    "faq-answer-6": "For periodar med uføretrygd blir 18,1 prosent av ei anteken inntekt lagd til pensjonsbehaldninga di. Dette gjeld til og med det året du fyller 61 år.",
+    "faq-question-6": "Korleis blir oppteninga for førstegongsteneste berekna?",
+    "faq-answer-6": "Du kan også få opptening til pensjonsbehaldninga basert på førstegongsteneste som du begynte på tidlegast i 2010. Oppteninga utgjer 18,1 prosent av grunnbeløpet i folketrygda (G).",
 
-    "faq-question-7": "Korleis blir oppteninga for førstegongsteneste berekna?",
-    "faq-answer-7": "Du kan også få opptening til pensjonsbehaldninga basert på førstegongsteneste som du begynte på tidlegast i 2010. Oppteninga utgjer 18,1 prosent av grunnbeløpet i folketrygda (G).",
+    "faq-question-7": "Kvifor har eg ikkje pensjonsbehaldning?",
+    "faq-answer-7": "Det er ikkje registrert pensjonsopptening eller pensjonspoeng. Nav får den pensjonsgivande inntekta frå Skatteetaten. Dersom du meiner noko er feil med inntekta, må du kontakte [Skatteetaten](https://www.skatteetaten.no/).",
 
-    "faq-question-8": "Kvifor har eg ikkje pensjonsbehaldning?",
-    "faq-answer-8": "Det er ikkje registrert pensjonsopptening eller pensjonspoeng. Nav får den pensjonsgivande inntekta frå Skatteetaten. Dersom du meiner noko er feil med inntekta, må du kontakte [det lokale skattekontoret] ditt (https://www.skatteetaten.no/).",
+    "faq-question-8": "Pensjonsopptening for deg som er fødd mellom 1954 og 1962",
+    "faq-answer-8": "Du kan tene opp pensjonsrettar frå det året du fylte 17 år, til og med det året du fyller 75 år. Dei som er fødde i perioden 1954–1962, tener opp alderspensjon etter gamle og nye reglar i folketrygdlova. Det betyr at du tener opp pensjonsrettar både gjennom pensjonspoeng og ei pensjonsbehaldning.",
 
-    "faq-question-9": "Kva betyr 'ikkje noko grunnlag'?",
-    "faq-answer-9": "Vi får pensjonsgivande inntekt frå Skatteetaten når skatteoppgjeret er klart. Fram til skatteoppgjeret er klart vil det visast ein tekst som seier 'ikkje noko grunnlag'.",
-
-    "faq-question-10": "Pensjonsopptening for deg som er fødd mellom 1954 og 1962",
-    "faq-answer-10": "Du kan tene opp pensjonsrettar frå det året du fylte 17 år, til og med det året du fyller 75 år. Dei som er fødde i perioden 1954–1962, tener opp alderspensjon etter gamle og nye reglar i folketrygdlova. Det betyr at du tener opp pensjonsrettar både gjennom pensjonspoeng og ei pensjonsbehaldning.",
-
-    "faq-question-11": "Kva er omsorgsopptening?",
-    "faq-answer-11": [
+    "faq-question-9": "Kva er omsorgsopptening?",
+    "faq-answer-9": [
         "Omsorgsopptening er ikkje ei ekstra lønn som du får betalt ut frå folketrygda, men ei ordning som bidreg til at du kan få høgare pensjon når du blir pensjonist. Du må vere medlem i folketrygda i omsorgsperioden for å ha rett til omsorgsopptening.",
         "Ordninga med omsorgsopptening blei innført i 1992 og er seinare utvida slik at personar med barn fødde før 1992, kan få denne oppteninga. Sjå meir forklaring under her."
     ]


### PR DESCRIPTION
## Oppsummering
 
 Oppdaterer FAQ-innhold for brukere født etter 1962 og overgangskullet (1954–1962) på bokmål, nynorsk og engelsk.
 
 ## Endringer
 
 ### 1. Ny brødtekst for «Hvordan beregnes opptjening for uføretrygd?» (kun overgangskull)
 I `faq_born_in_or_between_1954_and_1962.json` er svaret erstattet (tittel uendret):
 
 - **Bokmål:** «Vi beregner alderspensjonen din dels på grunnlag av pensjonsbeholdningen din og dels på grunnlag av pensjonspoeng.»
 - **Nynorsk:** «Vi bereknar alderspensjonen din dels på grunnlag av pensjonsbehaldninga di og dels på grunnlag av pensjonspoeng.»
 - **Engelsk:** «We calculate your retirement pension partly based on your pension balance and partly on your pension points.»
 
 ### 2. Skatteetaten-referanser oppdatert
 Teksten i lenka er endret (URL uendret):
 
 - **Bokmål:** «ditt lokale skattekontor» → «Skatteetaten»
 - **Nynorsk:** «det lokale skattekontoret ditt» → «Skatteetaten» *(fikset også en formateringsfeil slik at teksten nå vises som lenke)*
 - **Engelsk:** «your local tax office» → «the Norwegian Tax Administration»
 
 Gjelder både `faq_born_after_1962.json` og `faq_born_in_or_between_1954_and_1962.json`.
 
 ### 3. Fjernet accordion «Hvordan påvirket pensjonsreformen 2010 beholdningen min?»
 Fjernet fra både `faq_born_after_1962.json` og `faq_born_in_or_between_1954_and_1962.json` (nb/nn/en).
 
 ### 4. Fjernet accordion «Hva betyr 'ikke noe grunnlag'?»
 Fjernet fra både `faq_born_after_1962.json` og `faq_born_in_or_between_1954_and_1962.json` (nb/nn/en).
 
 ## Teknisk
 
 - Gjenværende `faq-question-*` / `faq-answer-*` nøkler er renummerert sekvensielt etter fjerningene.
 - `faq-number-of-questions` oppdatert: 11 → 9 (1954–1962) og 10 → 8 (etter 1962).